### PR TITLE
Add G935 support for most commands

### DIFF
--- a/libg933/src/lib.rs
+++ b/libg933/src/lib.rs
@@ -499,6 +499,10 @@ const SUPPORTED_DEVICES: &'static [DeviceMatch] = &[
         pid: 0x0a66,
         name: "G533 Headset",
     },
+    DeviceMatch {
+        pid: 0x0a87,
+        name: "G935 Headset",
+    },
 ];
 
 /// Static reference to information about a supported device


### PR DESCRIPTION
This appears to work perfectly for the following commands:
- g933-utils set buttons true
- g933-utils set buttons false
- g933-utils watch buttons

What doesn't work is g933-utils get battery.
I realize that there are these CSV files with charge/discharge curves that need to be added, but I don't know how to obtain them.